### PR TITLE
added probesize and analyzeduration options for ffprobe.getFileInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ ffprobe.getFileInfo('sample.mp4').then(result => {
 
 ```
 
+passing in probesize and analyzeduration 
+
+```javascript
+
+const ffprobe = require('@tugrul/ffprobe');
+
+ffprobe.getFileInfo({ filePath: 'sample.mp4', options: { probeSize: 1 * 1024 * 1024 * 1024, analyzeDuration: 1000 * 1000000 } }).then(result => {
+    console.log(result);
+});
+
+```
+
 
 ## Build Options
 

--- a/src/media-info-worker.h
+++ b/src/media-info-worker.h
@@ -16,7 +16,7 @@ namespace node_ffprobe {
 
 class MediaInfoWorker : public Napi::AsyncWorker {
 public:
-    MediaInfoWorker(const Napi::Env& env, const std::string& fileName, Napi::Promise::Deferred&& def);
+    MediaInfoWorker(const Napi::Env& env, const std::string& fileName, const uint64_t probeSize, const uint64_t analyzeDuration, Napi::Promise::Deferred&& def);
     void Execute() override;
     void OnOK() override;
     void OnError(const Napi::Error& error) override;
@@ -26,6 +26,8 @@ public:
 
 private:
     std::string fileName;
+    int64_t probeSize;
+    int64_t analyzeDuration;
     Napi::Promise::Deferred deferred;
     static std::mutex sharedContextMutex;
     AVFormatContext* avFormatContext = nullptr;


### PR DESCRIPTION
Added support for passing probesize and/or analyzeduration for handling larger media files.

```javascript
const ffprobe = require('@tugrul/ffprobe');

ffprobe.getFileInfo({ 
   filePath: 'sample.mkv', 
   options: { 
        probeSize: 1 * 1024 * 1024 * 1024, 
        analyzeDuration: 1000 * 1000000
   } 
});
```